### PR TITLE
Optimize lookup builder

### DIFF
--- a/plonky2/src/gadgets/lookup.rs
+++ b/plonky2/src/gadgets/lookup.rs
@@ -128,14 +128,14 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
                 let last_lut_gate = self.num_gates();
                 let num_lut_entries = LookupTableGate::num_slots(&self.config);
                 let num_lut_rows = (self.get_luts_idx_length(lut_index) - 1) / num_lut_entries + 1;
+                let gate =
+                    LookupTableGate::new_from_table(&self.config, lut.clone(), last_lut_gate);
                 // Also for `LookupTableGate` we replace the `num_lut_entries` calls to `find_slot`
                 // with a single call to `add_gate`; note that in this case there is no need to
                 // separately handle the last chunk of LUT entries that cannot fill all the slots of
                 // a `LookupTableGate`, as the generator already handles empty slots
                 for _ in 0..num_lut_rows {
-                    let gate =
-                        LookupTableGate::new_from_table(&self.config, lut.clone(), last_lut_gate);
-                    self.add_gate(gate, vec![]);
+                    self.add_gate(gate.clone(), vec![]);
                 }
 
                 let first_lut_gate = self.num_gates() - 1;

--- a/plonky2/src/gadgets/lookup.rs
+++ b/plonky2/src/gadgets/lookup.rs
@@ -107,7 +107,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
                 // handle chunks that can fill all the slots of a `LookupGate`
                 lookup_iter.for_each(|chunk| {
                     let row = self.add_gate(gate.clone(), vec![]);
-                    for (i,(looking_in, looking_out)) in chunk.iter().enumerate() {
+                    for (i, (looking_in, looking_out)) in chunk.iter().enumerate() {
                         let gate_in = Target::wire(row, LookupGate::wire_ith_looking_inp(i));
                         let gate_out = Target::wire(row, LookupGate::wire_ith_looking_out(i));
                         self.connect(gate_in, *looking_in);
@@ -115,7 +115,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
                     }
                 });
                 // deal with the last chunk
-                for (_,(looking_in, looking_out)) in last_chunk.iter().enumerate() {
+                for (_, (looking_in, looking_out)) in last_chunk.iter().enumerate() {
                     let (gate, i) =
                         self.find_slot(gate.clone(), &[F::from_canonical_usize(lut_index)], &[]);
                     let gate_in = Target::wire(gate, LookupGate::wire_ith_looking_inp(i));

--- a/plonky2/src/gadgets/lookup.rs
+++ b/plonky2/src/gadgets/lookup.rs
@@ -131,7 +131,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
                 // Also for `LookupTableGate` we replace the `num_lut_entries` calls to `find_slot`
                 // with a single call to `add_gate`; note that in this case there is no need to
                 // separately handle the last chunk of LUT entries that cannot fill all the slots of
-                // a `LookupTableGate`, as no generators are run even for non-empty slots
+                // a `LookupTableGate`, as the generator already handles empty slots
                 for _ in 0..num_lut_rows {
                     let gate =
                         LookupTableGate::new_from_table(&self.config, lut.clone(), last_lut_gate);

--- a/plonky2/src/gadgets/lookup.rs
+++ b/plonky2/src/gadgets/lookup.rs
@@ -92,11 +92,10 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
                 let gate = LookupGate::new_from_table(&self.config, lut.clone());
                 let num_slots = LookupGate::num_slots(&self.config);
 
-                /* Given the number of lookups and the number of slots for each gate, it is possible
-                 to compute the number of gates that will employ all their slots; for such gates,
-                 the `num_slots` calls to the `find_slot` function can be replaced with a single
-                 `add_gate` call.
-                */
+                // Given the number of lookups and the number of slots for each gate, it is possible
+                // to compute the number of gates that will employ all their slots; such gates can
+                // can be instantiated with `add_gate` rather than being instantiated slot by slot
+
                 // lookup_iter will iterate over the lookups that can be placed in fully utilized
                 // gates, splitting them in chunks that can be placed in the same `LookupGate`
                 let lookup_iter = lookups.chunks_exact(num_slots);
@@ -115,7 +114,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
                     }
                 });
                 // deal with the last chunk
-                for (_, (looking_in, looking_out)) in last_chunk.iter().enumerate() {
+                for (looking_in, looking_out) in last_chunk.iter() {
                     let (gate, i) =
                         self.find_slot(gate.clone(), &[F::from_canonical_usize(lut_index)], &[]);
                     let gate_in = Target::wire(gate, LookupGate::wire_ith_looking_inp(i));
@@ -130,10 +129,10 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
                 let num_lut_rows = (self.get_luts_idx_length(lut_index) - 1) / num_lut_entries + 1;
                 let gate =
                     LookupTableGate::new_from_table(&self.config, lut.clone(), last_lut_gate);
-                // Also for `LookupTableGate` we replace the `num_lut_entries` calls to `find_slot`
-                // with a single call to `add_gate`; note that in this case there is no need to
-                // separately handle the last chunk of LUT entries that cannot fill all the slots of
-                // a `LookupTableGate`, as the generator already handles empty slots
+                // Also instances of `LookupTableGate` can be placed with the `add_gate` function
+                // rather than being instantiated slot by slot; note that in this case there is no
+                // need to separately handle the last chunk of LUT entries that cannot fill all the
+                // slots of a `LookupTableGate`, as the generator already handles empty slots
                 for _ in 0..num_lut_rows {
                     self.add_gate(gate.clone(), vec![]);
                 }

--- a/plonky2/src/lookup_test.rs
+++ b/plonky2/src/lookup_test.rs
@@ -483,9 +483,9 @@ fn test_big_lut() -> anyhow::Result<()> {
     let config = CircuitConfig::standard_recursion_config();
     let mut builder = CircuitBuilder::<F, D>::new(config);
 
-    const LUT_SIZE: usize = u16::MAX as usize +1;
+    const LUT_SIZE: usize = u16::MAX as usize + 1;
     let inputs: [u16; LUT_SIZE] = core::array::from_fn(|i| i as u16);
-    let lut_fn = |inp: u16| inp/10;
+    let lut_fn = |inp: u16| inp / 10;
     let lut_index = builder.add_lookup_table_from_fn(lut_fn, &inputs);
 
     let initial_a = builder.add_virtual_target();
@@ -536,16 +536,18 @@ fn test_many_lookups_on_big_lut() -> anyhow::Result<()> {
     let config = CircuitConfig::standard_recursion_config();
     let mut builder = CircuitBuilder::<F, D>::new(config);
 
-    const LUT_SIZE: usize = u16::MAX as usize +1;
+    const LUT_SIZE: usize = u16::MAX as usize + 1;
     let inputs: [u16; LUT_SIZE] = core::array::from_fn(|i| i as u16);
-    let lut_fn = |inp: u16| inp/10;
+    let lut_fn = |inp: u16| inp / 10;
     let lut_index = builder.add_lookup_table_from_fn(lut_fn, &inputs);
 
-    let inputs = (0..LUT_SIZE).map(|_| {
-        let input_target = builder.add_virtual_target();
-        _ = builder.add_lookup_from_index(input_target, lut_index);
-        input_target
-    }).collect::<Vec<_>>();
+    let inputs = (0..LUT_SIZE)
+        .map(|_| {
+            let input_target = builder.add_virtual_target();
+            _ = builder.add_lookup_from_index(input_target, lut_index);
+            input_target
+        })
+        .collect::<Vec<_>>();
 
     let initial_a = builder.add_virtual_target();
     let initial_b = builder.add_virtual_target();
@@ -563,9 +565,10 @@ fn test_many_lookups_on_big_lut() -> anyhow::Result<()> {
 
     let mut pw = PartialWitness::new();
 
-    inputs.into_iter().enumerate().for_each(|(i,t)|
-        pw.set_target(t, F::from_canonical_usize(i))
-    );
+    inputs
+        .into_iter()
+        .enumerate()
+        .for_each(|(i, t)| pw.set_target(t, F::from_canonical_usize(i)));
     pw.set_target(initial_a, F::from_canonical_u16(look_val_a));
     pw.set_target(initial_b, F::from_canonical_u16(look_val_b));
 
@@ -576,7 +579,6 @@ fn test_many_lookups_on_big_lut() -> anyhow::Result<()> {
     );
 
     data.verify(proof)
-
 }
 
 fn init_logger() -> anyhow::Result<()> {


### PR DESCRIPTION
This PR optimizes the instantiation of `LookupGate` and `LookupTableGate` instances when building a circuit. The optimization seems to be particularly effective on big lookup tables (e.g., with 2^16 elements).
To this extent, I have added a couple of tests in `lookup_test.rs` that perform lookups over such a big lookup table. The speed up achieved by the optimization can be observed by running such tests before and after applying the commit introducing the optimization (that is, the "optimize lookup builder" commit with identifier 8c842a2048a0da933cd313c57ff671911438c9c6). 

This optimization might allow to significantly reduce the circuit building time when doing larger range checks or using hash functions with larger lookup tables. For example, while using 8-bit lookups by default, Monolith can also be used with 16-bit lookup tables in order to reduce the number of gates that need to be instantiated for each permutation.